### PR TITLE
Launch Time countdown

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,20 +11,17 @@ import { Card, Input, Text, View } from "@/components/Themed";
 import Container from "@/components/Container";
 import LaunchService from "@/services/LaunchesService";
 import { Launch, LaunchQueryResponse } from "@/types/LaunchServiceTypes";
-import dayjs from "dayjs";
-import advancedFormat from "dayjs/plugin/advancedFormat";
 import EmptyState from "@/components/EmptyList";
 import { useRouter } from "expo-router";
 import useSpaceXStorage from "@/store/spaceXStore";
-
-dayjs.extend(advancedFormat);
+import { formatLaunchDate } from "@/utils/formatDate";
 
 const { height: screenHeight } = Dimensions.get("screen");
 
 const PAGE_LIMIT = 10;
 type LaunchList = Pick<
   Launch,
-  "id" | "name" | "date_utc" | "links" | "details"
+  "id" | "name" | "date_utc" | "links" | "details" | "date_precision"
 >;
 
 const LaunchesScreen = () => {
@@ -63,6 +60,7 @@ const LaunchesScreen = () => {
                 id: 1,
                 name: 1,
                 date_utc: 1,
+                date_precision: 1,
                 links: 1,
                 details: 1,
               },
@@ -144,7 +142,7 @@ const LaunchesScreen = () => {
         {item.name}
       </Text>
       <Text textSize="h4" variant="default">
-        {dayjs(item.date_utc).format("Do MMMM YYYY [at] h:mm a")}
+        {formatLaunchDate(item.date_utc, item.date_precision)}
       </Text>
       <Text textSize="h6" variant="default" numberOfLines={3}>
         {item.details || "No details available"}

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,0 +1,32 @@
+import dayjs from "dayjs";
+
+export const formatLaunchDate = (
+  dateUtc: string,
+  precision: "quarter" | "half" | "year" | "month" | "day" | "hour"
+) => {
+  const d = dayjs(dateUtc);
+
+  switch (precision) {
+    case "year":
+      return d.format("YYYY");
+
+    case "half":
+      return `${d.format("YYYY")} (H${d.month() < 6 ? "1" : "2"})`;
+    // first half / second half of year
+
+    case "quarter":
+      return `${d.format("[Q]Q YYYY")}`;
+
+    case "month":
+      return d.format("MMMM YYYY");
+
+    case "day":
+      return d.format("Do MMMM YYYY");
+
+    case "hour":
+      return d.format("Do MMMM YYYY [at] h:mm a");
+
+    default:
+      return d.format("Do MMMM YYYY [at] h:mm a"); // fallback
+  }
+};


### PR DESCRIPTION
# Launch Time countdown

As per the discussion, I've implemented a launch time countdown.

## Steps taken to implement

1. A state `dateTimeDifference` is initiated to store the current countdown.
2. A `setInterval` event loop is executed in a `useEffect` while a `date_utc` field exists.
3. Using `day.js` we check the duration and humanize it, break it down into parts and check if the following parameters exist and is greater than 0
    - year
    - month
    - day
    - hour
    - minute
    - second
4. All these data are checked and pushed in an array and using the `Array.join` function `joined` string is generated
5. If `joined` length is 0 then as a fallback we set the state as "Rocket already launched".
6. Else the duration is set.

## Fault tolerance

During the implementation it is found that the spaceX api has a fault such that the launches that are marked `upcoming: true` are outdated. So the previous mentioned check for negative values is necessary.

## Additional feature

In the SpaceX documentation it is found that there is a precision to which the launch date is correct. The correction is applied by building a function in the `utils` directory such that there is a `formatLaunchDate` function which returns the date according to the precision.

<img width="300" height="750" alt="Screenshot_1755676842" src="https://github.com/user-attachments/assets/102e5f8e-bdd5-427a-89c5-c9931c263579" />